### PR TITLE
Feature: Add cursor extent property and location accessors

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -28,6 +28,7 @@ var CXCursor = d.CXCursor;
 var CXCursorVisitor = d.CXCursorVisitor;
 
 var Location = require('./location');
+var Range = require('./range');
 
 var util = require('./util');
 
@@ -78,6 +79,12 @@ var Cursor = function (instance) {
   Object.defineProperty(this, 'location', {
     get: function () {
       return new Location(lib.clang_getCursorLocation(self._instance));
+    }
+  });
+
+  Object.defineProperty(this, 'extent', {
+    get: function () {
+      return new Range(lib.clang_getCursorExtent(self._instance));
     }
   });
 

--- a/lib/dynamic_clang.js
+++ b/lib/dynamic_clang.js
@@ -966,6 +966,7 @@ exports.libclang = new FFI.Library('libclang', {
     clang_getPresumedLocation: [ref.types.void, [CXSourceLocation, CXStringPtr, voidPtr, voidPtr]],
     clang_getInstantiationLocation: [ref.types.void, [CXSourceLocation, CXFilePtr, voidPtr, voidPtr, voidPtr]],
     clang_getSpellingLocation: [ref.types.void, [CXSourceLocation, CXFilePtr, voidPtr, voidPtr, voidPtr]],
+    clang_getFileLocation: [ref.types.void, [CXSourceLocation, CXFilePtr, voidPtr, voidPtr, voidPtr]],
     clang_getRangeStart: [CXSourceLocation, [CXSourceRange]],
     clang_getRangeEnd: [CXSourceLocation, [CXSourceRange]],
     clang_getNumDiagnosticsInSet: [ref.types.uint32, [CXDiagnosticSet]],

--- a/lib/location.js
+++ b/lib/location.js
@@ -29,6 +29,26 @@ var Location = function (instance) {
   //TODO XXX FIXME clang_getNullLocation
   this._instance = instance;
 
+  Object.defineProperty(this, 'expansionLocation', {
+    get: function () {
+      var self = this;
+      var file = ref.alloc(lib.CXFile);
+      var line = ref.alloc(ref.types.uint32);
+      var column = ref.alloc(ref.types.uint32);
+      var offset = ref.alloc(ref.types.uint32);
+      lib.libclang.clang_getExpansionLocation(self._instance,
+        file, line, column, offset);
+
+      var filename = lib.libclang.clang_getFileName(file.deref());
+      return {
+        filename: util.toString(filename),
+        line: line.deref(),
+        column: column.deref(),
+        offset: offset.deref(),
+      };
+    },
+  });
+
   Object.defineProperty(this, 'presumedLocation', {
     get: function () {
       var self = this;
@@ -42,6 +62,66 @@ var Location = function (instance) {
         filename: util.toString(file.deref()),
         line: line.deref(),
         column: column.deref(),
+      };
+    },
+  });
+
+  Object.defineProperty(this, 'instantiationLocation', {
+    get: function () {
+      var self = this;
+      var file = ref.alloc(lib.CXFile);
+      var line = ref.alloc(ref.types.uint32);
+      var column = ref.alloc(ref.types.uint32);
+      var offset = ref.alloc(ref.types.uint32);
+      lib.libclang.clang_getInstantiationLocation(self._instance,
+        file, line, column, offset);
+
+      var filename = lib.libclang.clang_getFileName(file.deref());
+      return {
+        filename: util.toString(filename),
+        line: line.deref(),
+        column: column.deref(),
+        offset: offset.deref(),
+      };
+    },
+  });
+
+  Object.defineProperty(this, 'spellingLocation', {
+    get: function () {
+      var self = this;
+      var file = ref.alloc(lib.CXFile);
+      var line = ref.alloc(ref.types.uint32);
+      var column = ref.alloc(ref.types.uint32);
+      var offset = ref.alloc(ref.types.uint32);
+      lib.libclang.clang_getSpellingLocation(self._instance,
+        file, line, column, offset);
+
+      var filename = lib.libclang.clang_getFileName(file.deref());
+      return {
+        filename: util.toString(filename),
+        line: line.deref(),
+        column: column.deref(),
+        offset: offset.deref(),
+      };
+    },
+  });
+
+  Object.defineProperty(this, 'fileLocation', {
+    get: function () {
+      var self = this;
+      var file = ref.alloc(lib.CXFile);
+      var line = ref.alloc(ref.types.uint32);
+      var column = ref.alloc(ref.types.uint32);
+      var offset = ref.alloc(ref.types.uint32);
+      lib.libclang.clang_getFileLocation(self._instance,
+        file, line, column, offset);
+
+      var filename = lib.libclang.clang_getFileName(file.deref());
+      return {
+        filename: util.toString(filename),
+        line: line.deref(),
+        column: column.deref(),
+        offset: offset.deref(),
       };
     },
   });

--- a/lib/range.js
+++ b/lib/range.js
@@ -1,4 +1,4 @@
-// Copyright 2013 Timothy J Fontaine <tjfontaine@gmail.com>
+// Copyright 2014 Timothy J Fontaine <tjfontaine@gmail.com>
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the 'Software'), to deal
@@ -18,9 +18,29 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE
 
-exports.Cursor = require('./lib/cursor');
-exports.Index = require('./lib/index');
-exports.TranslationUnit = require('./lib/translationunit');
-exports.Type = require('./lib/type');
-exports.Location = require('./lib/location');
-exports.Range = require('./lib/range');
+var lib = require('./dynamic_clang');
+var Location = require('./location');
+
+var Range = function (instance) {
+  if (!(this instanceof Range))
+    return new Range(instance)
+
+  var self = this;
+
+  this._instance = instance;
+
+  Object.defineProperty(this, 'start', {
+    get: function () {
+      return new Location(lib.libclang.clang_getRangeStart(self._instance));
+    }
+  })
+
+  Object.defineProperty(this, 'end', {
+    get: function () {
+      return new Location(lib.libclang.clang_getRangeEnd(self._instance));
+    }
+  })
+}
+
+module.exports = Range
+


### PR DESCRIPTION
I was enjoying myself tinkering with your libclang binding. Here is the fallout:

Wrap type `Range` and expose `cursor.extent`. Also, add the other location accessors:
- `expansionLocation`
- `instantiationLocation`
- `spellingLocation`
- `fileLocation`
